### PR TITLE
Small accessibility improvement

### DIFF
--- a/styles/_reset.scss
+++ b/styles/_reset.scss
@@ -27,7 +27,7 @@ button {
   margin: 0;
   border: none;
   color: $white;
-  outline: none;
+  outline-color: transparent;
 }
 .flex {
   display: flex;


### PR DESCRIPTION
Changed the outline from none to outline-color: transparent for accessibility purposes. It helps people with higher contrasts on their OS still have access to all effects on the button.
Reference for this change: https://www.youtube.com/shorts/4B_4WLpbyp8